### PR TITLE
recursively create directories

### DIFF
--- a/sarc.py
+++ b/sarc.py
@@ -294,7 +294,7 @@ class Sarc:
                     dirname = os.path.dirname(filename)
                     if len(dirname) > 0 and not os.path.exists(dirname):
                         try:
-                            os.mkdir(dirname)
+                            os.makedirs(dirname)
                         except OSError:
                             print("Couldn't create directory: %s" % dirname)
                             return


### PR DESCRIPTION
this should solve a problem I encountered extracting an SARC from Nintendo Badge Arcade:
```
python2 sarc.py -f nnid.sarc -x
Couldn't create directory: talkpic/nnid
```
...unless "talkpic" was created manually.