### PR TITLE
Fix pypng expecting greyscale colors

### DIFF
--- a/bcfnt.py
+++ b/bcfnt.py
@@ -335,7 +335,7 @@ class Bffnt:
                 png_data.append(row)
 
             file_ = open('%s_sheet%d.png' % (basename_, i), 'wb')
-            writer = png.Writer(width, height, alpha=True)
+            writer = png.Writer(width, height, greyscale=False, alpha=True)
             writer.write(file_, png_data)
             file_.close()
         print('Done')


### PR DESCRIPTION
The latest version of pypng (0.20) [made a breaking change](https://github.com/drj11/pypng#release-0020) setting by default `greyscale=True` in the constructor of `png.Writer`. As a consequence, the script doesn't work because it's expecting colors in greyscale format instead of RGB.

This PR specify that the final image is not greyscale, so it will expect RGBA colors as before.